### PR TITLE
Update appimagetool URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ cmake: $(CMAKE)
 
 # AppImageTool
 appimagetool:
-	curl $(CURL_DOH_URL) -Lfo appimagetool https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$(ARCH).AppImage
+	curl $(CURL_DOH_URL) -Lfo appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$(ARCH).AppImage
 	chmod u+x appimagetool
 ifneq ($(QEMU),)
 # Extract the AppImageTool


### PR DESCRIPTION
AppImageKit has made their releases of appimagetool [obsolete](https://github.com/AppImage/AppImageKit/releases), causing the Makefile to throw a 404.

This PR updates the URL to point to the new location in the [appimagetool repo](https://github.com/AppImage/appimagetool/releases).